### PR TITLE
Backport fixes for "unknown service types.API" from upstream

### DIFF
--- a/supervisor/delete.go
+++ b/supervisor/delete.go
@@ -27,13 +27,14 @@ func (s *Supervisor) delete(t *DeleteTask) error {
 			t.Process.Wait()
 		}
 		if !t.NoEvent {
-			execMap := s.getDeleteExecSyncMap(t.ID)
+			execMap := s.getExecSyncMap(t.ID)
 			go func() {
 				// Wait for all exec processe events to be sent (we seem
 				// to sometimes receive them after the init event)
 				for _, ch := range execMap {
 					<-ch
 				}
+				s.deleteExecSyncMap(t.ID)
 				s.notifySubscribers(Event{
 					Type:      StateExit,
 					Timestamp: time.Now(),

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -431,10 +431,14 @@ func (s *Supervisor) getExecSyncChannel(containerID, pid string) chan struct{} {
 	return ch
 }
 
-func (s *Supervisor) getDeleteExecSyncMap(containerID string) map[string]chan struct{} {
+func (s *Supervisor) getExecSyncMap(containerID string) map[string]chan struct{} {
 	s.containerExecSyncLock.Lock()
-	chs := s.containerExecSync[containerID]
+	defer s.containerExecSyncLock.Unlock()
+	return s.containerExecSync[containerID]
+}
+
+func (s *Supervisor) deleteExecSyncMap(containerID string) {
+	s.containerExecSyncLock.Lock()
+	defer s.containerExecSyncLock.Unlock()
 	delete(s.containerExecSync, containerID)
-	s.containerExecSyncLock.Unlock()
-	return chs
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -334,8 +334,10 @@ func (s *Supervisor) restore() error {
 			return err
 		}
 		processes, err := container.Processes()
-		if err != nil {
-			return err
+		if err != nil || len(processes) == 0 {
+			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: container has no process running,removing state directory.")
+			os.RemoveAll(filepath.Join(s.stateDir, id))
+			continue
 		}
 
 		ContainersCounter.Inc(1)


### PR DESCRIPTION
Two fixes went into the upstream project for the "unknown service types.API" issue.
So backporting those here.

These are the fixes:
https://github.com/containerd/containerd/pull/872
https://github.com/containerd/containerd/pull/828

A customer was seeing this error in their environment.

cc @mrunalp @runcom 