### PR TITLE
dockerd logs "rpc error: code = 2 desc = containerd: container not found" after various API requests

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -146,15 +146,15 @@ func New(opts ContainerOpts) (Container, error) {
 }
 
 // Load return a new container from the matchin state file on disk.
-func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
+func Load(root, id, shimName string, timeout time.Duration) (Container, error, string) {
 	var s state
 	f, err := os.Open(filepath.Join(root, id, StateFile))
 	if err != nil {
-		return nil, err
+		return nil, err, "init"
 	}
 	defer f.Close()
 	if err := json.NewDecoder(f).Decode(&s); err != nil {
-		return nil, err
+		return nil, err, "init"
 	}
 	c := &container{
 		root:        root,
@@ -175,7 +175,7 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
 
 	dirs, err := ioutil.ReadDir(filepath.Join(root, id))
 	if err != nil {
-		return nil, err
+		return nil, err, "init"
 	}
 	for _, d := range dirs {
 		if !d.IsDir() {
@@ -184,7 +184,7 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
 		pid := d.Name()
 		s, err := readProcessState(filepath.Join(root, id, pid))
 		if err != nil {
-			return nil, err
+			return nil, err, pid
 		}
 		p, err := loadProcess(filepath.Join(root, id, pid), pid, c, s)
 		if err != nil {
@@ -193,7 +193,7 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
 		}
 		c.processes[pid] = p
 	}
-	return c, nil
+	return c, nil, ""
 }
 
 func readProcessState(dir string) (*ProcessState, error) {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -334,10 +334,15 @@ func (s *Supervisor) restore() error {
 			continue
 		}
 		id := d.Name()
-		container, err := runtime.Load(s.stateDir, id, s.shim, s.timeout)
+		container, err, pid := runtime.Load(s.stateDir, id, s.shim, s.timeout)
 		if err != nil {
-			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state directory.")
-			os.RemoveAll(filepath.Join(s.stateDir, id))
+			if (pid == "init") {
+				logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state directory.")
+				os.RemoveAll(filepath.Join(s.stateDir, id))
+			} else {
+				logrus.WithFields(logrus.Fields{"error": err, "pid": pid}).Warnf("containerd: failed to load exec process,removing state directory.")
+				os.RemoveAll(filepath.Join(s.stateDir, id, pid))
+			}
 			continue
 		}
 		processes, err := container.Processes()


### PR DESCRIPTION
The error message indicates that there is an inconsistency between docker's view
of existing containers and containerd's view. From the perspective of dockerd the
container still exists whereas the container is unknown to containerd. A possible
scenario that can cause such an inconsistency looks like this:

- Containerd is handling an 'AddProcessTask' API request from dockerd. Containerd
  executes the Exec() function in runtime/container.go which creates the directory
  /run/docker/libcontainerd/containerd/CONTAINERID/PROCESSID and the process.json
  file in that directory.

- Containerd gets killed, for example, by the handleConnectionChange() function in
  libcontainerd/remote_unix.go after creating the directory but before creating the
  JSON file.

- The new instance of containerd that gets started by handleConnectionChange() first
  executes the restore() function that 'imports' (loads) existing containers. This
  function receives an error from runtime.Load() because the CONTAINERID/PROCESSID
  directory exists but the process.json file is missing.

- The error handling code path in the restore() function now removes the _entire_
  /run/docker/libcontainerd/containerd/CONTAINERID directory recursively. This is
  the point when the container becomes unknown to containerd. However, since only
  an exec'ed process was impacted by the kill and restart of containerd the 'init'
  process of the container still exists and should thus be known to containerd.

The error handling code path that was introduced by commit [296f1f8](https://github.com/projectatomic/containerd/commit/296f1f80d6c6a83cc625163f863e53d3287328ee) appears to be
incomplete because it does not distinguish whether the error from runtime.Load()
is related to the 'init' process or to an exec'ed process. The restore() function
should only remove /run/docker/libcontainerd/containerd/CONTAINERID/PROCESSID if
the error is related to an exec'ed process.

The proposed patch in this pull request aims to address this issue.