### PR TITLE
dockerd logs "rpc error: code = 2 desc = containerd: container not found" after various API requests

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -146,15 +146,15 @@ func New(opts ContainerOpts) (Container, error) {
 }
 
 // Load return a new container from the matchin state file on disk.
-func Load(root, id, shimName string, timeout time.Duration) (Container, error, string) {
+func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
 	var s state
 	f, err := os.Open(filepath.Join(root, id, StateFile))
 	if err != nil {
-		return nil, err, "init"
+		return nil, err
 	}
 	defer f.Close()
 	if err := json.NewDecoder(f).Decode(&s); err != nil {
-		return nil, err, "init"
+		return nil, err
 	}
 	c := &container{
 		root:        root,
@@ -175,7 +175,7 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error, s
 
 	dirs, err := ioutil.ReadDir(filepath.Join(root, id))
 	if err != nil {
-		return nil, err, "init"
+		return nil, err
 	}
 	for _, d := range dirs {
 		if !d.IsDir() {
@@ -184,7 +184,7 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error, s
 		pid := d.Name()
 		s, err := readProcessState(filepath.Join(root, id, pid))
 		if err != nil {
-			return nil, err, pid
+			return nil, err
 		}
 		p, err := loadProcess(filepath.Join(root, id, pid), pid, c, s)
 		if err != nil {
@@ -193,7 +193,7 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error, s
 		}
 		c.processes[pid] = p
 	}
-	return c, nil, ""
+	return c, nil
 }
 
 func readProcessState(dir string) (*ProcessState, error) {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -182,11 +182,14 @@ func Load(root, id, shimName string, timeout time.Duration) (Container, error) {
 			continue
 		}
 		pid := d.Name()
-		s, err := readProcessState(filepath.Join(root, id, pid))
+		processStateDir := filepath.Join(root, id, pid)
+		s, err := readProcessState(processStateDir)
 		if err != nil {
-			return nil, err
+			logrus.WithFields(logrus.Fields{"error": err, "pid": pid}).Warnf("containerd: failed to load exec process,removing state directory.")
+			os.RemoveAll(processStateDir)
+			continue
 		}
-		p, err := loadProcess(filepath.Join(root, id, pid), pid, c, s)
+		p, err := loadProcess(processStateDir, pid, c, s)
 		if err != nil {
 			logrus.WithField("id", id).WithField("pid", pid).Debugf("containerd: error loading process %s", err)
 			continue

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -364,15 +364,10 @@ func (s *Supervisor) restore() error {
 			continue
 		}
 		id := d.Name()
-		container, err, pid := runtime.Load(s.stateDir, id, s.shim, s.timeout)
+		container, err := runtime.Load(s.stateDir, id, s.shim, s.timeout)
 		if err != nil {
-			if (pid == "init") {
-				logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state directory.")
-				os.RemoveAll(filepath.Join(s.stateDir, id))
-			} else {
-				logrus.WithFields(logrus.Fields{"error": err, "pid": pid}).Warnf("containerd: failed to load exec process,removing state directory.")
-				os.RemoveAll(filepath.Join(s.stateDir, id, pid))
-			}
+			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state directory.")
+			os.RemoveAll(filepath.Join(s.stateDir, id))
 			continue
 		}
 		processes, err := container.Processes()


### PR DESCRIPTION
A flaw was found in the code changes that were introduced by commit [e96a10a](https://github.com/projectatomic/containerd/commit/e96a10aef66e6d5f78cf6abad1398498d486c241). Under certain conditions, the scenario that is outlined in https://github.com/projectatomic/containerd/pull/10 can still cause 'container not found' errors. This pull request consists of two commits:

- The first commit reverts commit e96a10a.
- The second commit proposes a new approach to address to original issue.