### PR TITLE
Security: fix mem leak in containerd

### DIFF
--- a/supervisor/delete.go
+++ b/supervisor/delete.go
@@ -27,11 +27,14 @@ func (s *Supervisor) delete(t *DeleteTask) error {
 			t.Process.Wait()
 		}
 		if !t.NoEvent {
-			execMap := s.getExecSyncMap(t.ID)
 			go func() {
 				// Wait for all exec processe events to be sent (we seem
 				// to sometimes receive them after the init event)
-				for _, ch := range execMap {
+				for {
+					ch := s.getExecSyncOneChannel(t.ID)
+					if ch == nil {
+						break
+					}
 					<-ch
 				}
 				s.deleteExecSyncMap(t.ID)

--- a/supervisor/exit.go
+++ b/supervisor/exit.go
@@ -89,6 +89,7 @@ func (s *Supervisor) execExit(t *ExecExitTask) error {
 			PID:       t.PID,
 			Status:    t.Status,
 		})
+		s.deleteExecSyncChannel(t.ID, t.PID)
 		close(synCh)
 	}()
 	return nil

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -479,10 +479,14 @@ func (s *Supervisor) getExecSyncChannel(containerID, pid string) chan struct{} {
 	return ch
 }
 
-func (s *Supervisor) getExecSyncMap(containerID string) map[string]chan struct{} {
+func (s *Supervisor) getExecSyncOneChannel(containerID string) chan struct{} {
 	s.containerExecSyncLock.Lock()
 	defer s.containerExecSyncLock.Unlock()
-	return s.containerExecSync[containerID]
+
+	for _, ch := range s.containerExecSync[containerID] {
+		return ch
+	}
+	return nil
 }
 
 func (s *Supervisor) deleteExecSyncMap(containerID string) {


### PR DESCRIPTION
This is a backport of containerd/containerd#1993 to docker-1.13.1-rhel branch.

Clean cherry-pick, no issues.